### PR TITLE
Stop calling zeroOffsets - for dual energy running

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -11,6 +11,11 @@
 #               2018, W. Williams        (ernesto)
 #      
 #==============================================================
+R3.2.1:   25-August-2020 J. Mock (jmock)
+    * Remove calls to zeroOffset() in Longitudinal.cc to stop SXR loop from snapping
+        to HXR value when the beam trips off
+    * Also comment out _referenceOffset = 0 in ActuatorDevice.cc::clear() for same reason
+
 R3.2.0:   25-August-2020 R.Reno (rreno)
     * Add ability to select BY1 energy source at IOC startup
     * Fixed bug where error handling code for an FCOM channel creation failure would never run

--- a/fastFeedbackApp/src/framework/ActuatorDevice.cc
+++ b/fastFeedbackApp/src/framework/ActuatorDevice.cc
@@ -261,7 +261,7 @@ void ActuatorDevice::clear() {
     Device::clear();
     _nextWrite = 0;
     _droppedPoints = 0;
-    _referenceOffset = 0;
+    //_referenceOffset = 0;
     Log::getInstance() << Log::flagOffset << Log::dpInfo
 		       << "ActuatorDevice::clear() _referenceOffset=0"
 		       << Log::dp;

--- a/fastFeedbackApp/src/framework/Longitudinal.cc
+++ b/fastFeedbackApp/src/framework/Longitudinal.cc
@@ -1171,7 +1171,8 @@ int Longitudinal::selectStates() {
 		_latestMeasurementsSum[0] = 0;
 
 		// Zero actuator offsets!
-		actuatorDevice->zeroOffset();
+    //2020-08-21 J. Mock remove this for dual energy operation
+		//actuatorDevice->zeroOffset();
 	}
 	stateDevice->setUsedBy(stateUsed);
 	actuatorDevice->setUsedBy(stateUsed);
@@ -1252,7 +1253,8 @@ int Longitudinal::selectStates() {
 		_latestMeasurementsSum[1] = 0;
 
 		// Zero actuator offsets!
-		actuatorDevice->zeroOffset();
+    //2020-08-21 J. Mock remove this for dual energy operation
+		//actuatorDevice->zeroOffset();
 	}
 
 	stateDevice->setUsedBy(stateUsed);
@@ -1338,7 +1340,8 @@ int Longitudinal::selectStates() {
 		_latestMeasurementsSum[2] = 0;
 
 		// Zero actuator offsets!
-		actuatorDevice->zeroOffset();
+    //2020-08-21 J. Mock remove this for dual energy operation
+		//actuatorDevice->zeroOffset();
 	}
 	stateDevice->setUsedBy(stateUsed);
 	actuatorDevice->setUsedBy(stateUsed);
@@ -1417,7 +1420,8 @@ int Longitudinal::selectStates() {
 		_latestMeasurementsSum[3] = 0;
 
 		// Zero actuator offsets!
-		actuatorDevice->zeroOffset();
+    //2020-08-21 J. Mock remove this for dual energy operation
+		//actuatorDevice->zeroOffset();
 	}
 	stateDevice->setUsedBy(stateUsed);
 	actuatorDevice->setUsedBy(stateUsed);
@@ -1498,7 +1502,8 @@ int Longitudinal::selectStates() {
 		_latestMeasurementsSum[4] = 0;
 
 		// Zero actuator offsets!
-		actuatorDevice->zeroOffset();
+    //2020-08-21 J. Mock remove this for dual energy operation
+		//actuatorDevice->zeroOffset();
 	}
 	stateDevice->setUsedBy(stateUsed);
 	actuatorDevice->setUsedBy(stateUsed);
@@ -1652,7 +1657,8 @@ int Longitudinal::selectStates() {
 		_latestMeasurementsSum[5] = 0;
 
 		// Zero actuator offsets!
-		actuatorDevice->zeroOffset();
+    //2020-08-21 J. Mock remove this for dual energy operation
+		//actuatorDevice->zeroOffset();
 	}
 	stateDevice->setUsedBy(stateUsed);
 	actuatorDevice->setUsedBy(stateUsed);


### PR DESCRIPTION
* By default whenever beam went away or feedback turned off offsets were set to 0, snapping all 4 data slots to DS1.  This stops that from happening as it is quite invasive to dual energy running.